### PR TITLE
Integrate social sharing options on DiaryEntryPage.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react-redux": "^9.1.0",
         "react-router-dom": "^6.22.3",
         "react-scripts": "5.0.1",
+        "react-share": "^5.1.0",
         "react-tooltip": "^5.26.3",
         "redux-thunk": "^3.1.0",
         "web-vitals": "^2.1.4"
@@ -15128,6 +15129,27 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/jsonp/-/jsonp-0.2.1.tgz",
+      "integrity": "sha512-pfog5gdDxPdV4eP7Kg87M8/bHgshlZ5pybl+yKxAnCZ5O7lCIn7Ixydj03wOlnDQesky2BPyA91SQ+5Y/mNwzw==",
+      "dependencies": {
+        "debug": "^2.1.3"
+      }
+    },
+    "node_modules/jsonp/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/jsonp/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
     "node_modules/jsonpath": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
@@ -19266,6 +19288,18 @@
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/react-share": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-share/-/react-share-5.1.0.tgz",
+      "integrity": "sha512-OvyfMtj/0UzH1wi90OdHhZVJ6WUC/+IeWvBwppeZozwIGyAjQgyR0QXlHOrxVHVECqnGvcpBaFTXVrqouTieaw==",
+      "dependencies": {
+        "classnames": "^2.3.2",
+        "jsonp": "^0.2.1"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18"
       }
     },
     "node_modules/react-side-effect": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-redux": "^9.1.0",
     "react-router-dom": "^6.22.3",
     "react-scripts": "5.0.1",
+    "react-share": "^5.1.0",
     "react-tooltip": "^5.26.3",
     "redux-thunk": "^3.1.0",
     "web-vitals": "^2.1.4"

--- a/src/shared/quote-card/QuoteCard.tsx
+++ b/src/shared/quote-card/QuoteCard.tsx
@@ -14,6 +14,12 @@ import { useState } from "react";
 import { getModalColor } from "../utils/quote_card";
 import { MdClose } from "react-icons/md";
 import { Snackbar } from "@mui/material";
+import {
+  FacebookShareButton,
+  TwitterShareButton,
+  RedditShareButton,
+} from "react-share";
+import { FaFacebook, FaTwitter, FaReddit } from "react-icons/fa";
 
 const QUOTE_ICON_SIZE = 42;
 
@@ -119,9 +125,27 @@ export default function QuoteCard(props: {
         <div className="share-options">
           <div className="share-icons-parent">
             <div className="share-icon">
-              <IconButton onClick={share}>
-                <FaRegShareSquare size={24} color="white" />
-              </IconButton>
+              <FacebookShareButton
+                url={`https://mnemo.app/journal/${entityName}`}
+                hashtag="#MnemoApp"
+              >
+                <FaFacebook size={24} />
+              </FacebookShareButton>
+            </div>
+            <div className="share-icon">
+              <TwitterShareButton
+                url={`https://mnemo.app/journal/${entityName}`}
+                hashtags={["MnemoApp", "genAI", `${entityName}`]}
+              >
+                <FaTwitter size={24} />
+              </TwitterShareButton>
+            </div>
+            <div className="share-icon">
+              <RedditShareButton
+                url={`https://mnemo.app/journal/${entityName}`}
+              >
+                <FaReddit size={24} />
+              </RedditShareButton>
             </div>
             <div className="share-icon">
               <IconButton onClick={copyText}>


### PR DESCRIPTION
Utilize react-share library to add support for sharing diary entries on Reddit, Twitter and Facebook.

The shared content consists of a URL reference to the current diary entry of the entity specified by the URL. This means that the content of the URL will eventually be replaced by the next day's diary entry. This behavior is fine for now, but may warrant updating later - As of this merge, there exists no diary entry archival system.